### PR TITLE
Adds support for specifying zero offsets

### DIFF
--- a/src/_html-grid.scss
+++ b/src/_html-grid.scss
@@ -102,12 +102,15 @@
 							order: -1;
 						}
 
-					// Columns, offsets.
+					// Columns.
 						@for $i from 1 through $cols {
 							> .col-#{$i}#{$suffix} {
 								width: $unit * $i;
 							}
-
+						}
+						
+					// Offsets need to include a 0 so responsive layouts can override a default offset on smaller devices.
+						@for $i from 0 through $cols {
 							> .off-#{$i}#{$suffix} {
 								margin-left: $unit * $i;
 							}


### PR DESCRIPTION
I've used colums and offsets to control element width in a few places, like so:
```
<div class="row">
   <div class="col-8 off-2 col-12-small off-0-small">
      content goes here
  </div>
</div>
```
Which needs a set of `off-0-???` classes generated for the various scenarios where it can be applied.